### PR TITLE
Add yarn editor to ink editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The repositories marked with ⭐️ are compatible with the latest version of In
 - [Borogove](https://borogove.app/) - Tool to write, play and share interactive fiction entirely online, with support for ink.
 - [Quill](https://github.com/MattConrad/Quill) – Quill is an online tool for playing and sandbox testing Ink stories.
 - [Ink Language Server](https://github.com/ephread/ink/tree/language-server/inklecate/LanguageServerProtocol) – A language server for inkle's Ink, that adheres to the Language Server Protocol (LSP).
-- [Yarn Editor](https://yarnspinnertool.github.io/YarnEditor/) - A Pwa Desktop/Mobile app that can author, play and compile ink files via the inklecate wasm port and inkjs.
+- [Yarn Editor](https://yarnspinnertool.github.io/YarnEditor/) - A Pwa Desktop/Mobile 📱💻 app that can author, play and compile ink files via the inklecate wasm port and inkjs.
 
 #### Atom extensions
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The repositories marked with ⭐️ are compatible with the latest version of In
 - [Borogove](https://borogove.app/) - Tool to write, play and share interactive fiction entirely online, with support for ink.
 - [Quill](https://github.com/MattConrad/Quill) – Quill is an online tool for playing and sandbox testing Ink stories.
 - [Ink Language Server](https://github.com/ephread/ink/tree/language-server/inklecate/LanguageServerProtocol) – A language server for inkle's Ink, that adheres to the Language Server Protocol (LSP).
+- [Yarn Editor](https://yarnspinnertool.github.io/YarnEditor/) - A Pwa Desktop/Mobile app that can author, play and compile ink files via the inklecate wasm port and inkjs.
 
 #### Atom extensions
 


### PR DESCRIPTION
This adds the yarn editor pwa to the ink editors
https://yarnspinnertool.github.io/YarnEditor/
https://github.com/YarnSpinnerTool/YarnEditor/

It can read/write/compile and syntax highlight ink files
https://twitter.com/blurymind/status/1454910348570550276
https://twitter.com/blurymind/status/1454907240629026818
![inkPlaytest](https://user-images.githubusercontent.com/6495061/139601627-7dab52fd-8c33-4655-b397-c475aa69ddcf.gif)


